### PR TITLE
Clear command history on mode change

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -32,7 +32,7 @@ public interface Logic {
     ReadOnlyAddressBook getAddressBook();
 
     /** Returns an unmodifiable view of the filtered list of persons */
-    ObservableList<Person> getFilteredPersonList(AppMode appMode);
+    ObservableList<Person> getFilteredPersonList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -79,8 +79,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Person> getFilteredPersonList(AppMode appMode) {
-        return model.getFilteredPersonList(appMode);
+    public ObservableList<Person> getFilteredPersonList() {
+        return model.getFilteredPersonList(modeManager.getMode());
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CommandHistory.java
+++ b/src/main/java/seedu/address/ui/CommandHistory.java
@@ -39,4 +39,12 @@ public class CommandHistory extends UiPart<Region> {
         }
     }
 
+    /**
+     * Clears the in-memory and displayed command history.
+     */
+    public void clear() {
+        log.clear();
+        commandHistory.clear();
+    }
+
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -31,9 +31,6 @@ public class MainWindow extends UiPart<Stage> {
     private Stage primaryStage;
     private Logic logic;
 
-    // Current operating mode of the app.
-    private AppMode currentMode;
-
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private CommandHistory commandHistory;
@@ -63,8 +60,6 @@ public class MainWindow extends UiPart<Stage> {
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
-
-        currentMode = logic.getCurrentMode();
 
         helpWindow = new HelpWindow();
     }
@@ -117,7 +112,7 @@ public class MainWindow extends UiPart<Stage> {
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
         // Initialise the UI to the current mode (should be LOCKED at startup)
-        setMode(currentMode);
+        updateUi(logic.getCurrentMode());
 
         // summaryPlaceholder is a layout placeholder for now.
     }
@@ -135,7 +130,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     private void refreshPersonListPanel() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList(currentMode));
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().setAll(personListPanel.getRoot());
     }
 
@@ -152,10 +147,9 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Switches the app's operating mode and updates the UI accordingly.
+     * Updates the UI according to the current mode.
      */
-    private void setMode(AppMode mode) {
-        currentMode = mode;
+    private void updateUi(AppMode mode) {
         boolean isLocked = mode == AppMode.LOCKED;
         primaryStage.setTitle(isLocked ? "AddressBook" : "Spyglass");
         refreshPersonListPanel();
@@ -191,7 +185,10 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
 
             // Handle mode change if requested by the command result
-            commandResult.getRequestedMode().ifPresent(this::setMode);
+            commandResult.getRequestedMode().ifPresent(mode -> {
+                commandHistory.clear();
+                updateUi(mode);
+            });
 
             logger.info("Result: " + commandResult.getFeedbackToUser());
             commandHistory.setFeedbackToUser(commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -87,7 +87,7 @@ public class LogicManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () ->
-                logic.getFilteredPersonList(logic.getCurrentMode()).remove(0));
+                logic.getFilteredPersonList().remove(0));
     }
 
     /**

--- a/src/test/java/seedu/address/security/SecurityManagerTest.java
+++ b/src/test/java/seedu/address/security/SecurityManagerTest.java
@@ -139,7 +139,7 @@ public class SecurityManagerTest {
         }
 
         @Override
-        public ObservableList<Person> getFilteredPersonList(AppMode appMode) {
+        public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
- Clear command history on lock/unlock via `updateUi` in MainWindow
- Centralize mode handling in Logic and remove AppMode storage in MainWindow
- Simplify `getFilteredPersonList()` to use AppMode directly instead of passing param