### PR TITLE
Improve result history trace format

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -193,7 +193,11 @@ public class MainWindow extends UiPart<Stage> {
     private void refreshPersonListPanel() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanel.setOnSelectionChange(person -> {
-            personDetailPanel.setPerson(person);
+            if (person == null) {
+                personDetailPanel.clearPerson();
+            } else {
+                personDetailPanel.setPerson(person);
+            }
         });
         personListPanelPlaceholder.getChildren().setAll(personListPanel.getRoot());
     }
@@ -216,8 +220,8 @@ public class MainWindow extends UiPart<Stage> {
     private void updateUi(AppMode mode) {
         boolean isLocked = mode == AppMode.LOCKED;
         primaryStage.setTitle(isLocked ? "AddressBook" : "Spyglass");
-        refreshPersonListPanel();
         personDetailPanel.clearPerson();
+        refreshPersonListPanel();
     }
 
     void show() {
@@ -279,7 +283,6 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
-            resultHistory.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             // Handle mode change if requested by the command result
             boolean isModeChangedToUnlocked = commandResult.getRequestedMode().isPresent()
@@ -292,6 +295,13 @@ public class MainWindow extends UiPart<Stage> {
                 updateUi(mode);
             });
 
+            // Only show feedback for unlock; lock clears and stays blank
+            if (isModeChangedToUnlocked) {
+                resultHistory.setFeedbackToUser(commandText, commandResult.getFeedbackToUser());
+            } else if (commandResult.getRequestedMode().isEmpty()) {
+                resultHistory.setFeedbackToUser(commandText, commandResult.getFeedbackToUser());
+            }
+
             // Handle setup transition
             if (commandResult.isShowSetup()) {
                 handleSetup();
@@ -300,9 +310,6 @@ public class MainWindow extends UiPart<Stage> {
             commandResult.getSelectedIndex().ifPresent(personListPanel::select);
 
             logger.info("Result: " + commandResult.getFeedbackToUser());
-            if (isModeChangedToUnlocked) {
-                resultHistory.setFeedbackToUser(commandResult.getFeedbackToUser());
-            }
 
             if (commandResult.isShowHelp()) {
                 handleHelp();
@@ -315,7 +322,7 @@ public class MainWindow extends UiPart<Stage> {
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);
-            resultHistory.setFeedbackToUser(e.getMessage());
+            resultHistory.setFeedbackToUser(commandText, e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/seedu/address/ui/ResultHistory.java
+++ b/src/main/java/seedu/address/ui/ResultHistory.java
@@ -30,12 +30,30 @@ public class ResultHistory extends UiPart<Region> {
 
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
-        log.add(feedbackToUser);
+        appendEntry(formatFeedbackEntry(feedbackToUser));
+    }
+
+    public void setFeedbackToUser(String commandText, String feedbackToUser) {
+        requireNonNull(commandText);
+        requireNonNull(feedbackToUser);
+        appendEntry(formatCommandResultEntry(commandText, feedbackToUser));
+    }
+
+    static String formatFeedbackEntry(String feedbackToUser) {
+        return "> " + feedbackToUser;
+    }
+
+    static String formatCommandResultEntry(String commandText, String feedbackToUser) {
+        return "> " + commandText + "\n" + feedbackToUser;
+    }
+
+    private void appendEntry(String entry) {
+        log.add(entry);
 
         if (resultHistory.getText().isEmpty()) {
-            resultHistory.setText("> " + feedbackToUser);
+            resultHistory.setText(entry);
         } else {
-            resultHistory.appendText("\n\n> " + feedbackToUser);
+            resultHistory.appendText("\n\n" + entry);
         }
     }
 

--- a/src/test/java/seedu/address/ui/ResultHistoryTest.java
+++ b/src/test/java/seedu/address/ui/ResultHistoryTest.java
@@ -1,0 +1,19 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ResultHistoryTest {
+
+    @Test
+    public void formatFeedbackEntry_formatsWithPromptPrefix() {
+        assertEquals("> Result OUTPUT", ResultHistory.formatFeedbackEntry("Result OUTPUT"));
+    }
+
+    @Test
+    public void formatCommandResultEntry_formatsAsTwoLines() {
+        assertEquals("> CMD entered\nResult OUTPUT",
+                ResultHistory.formatCommandResultEntry("CMD entered", "Result OUTPUT"));
+    }
+}


### PR DESCRIPTION

<img width="910" height="666" alt="image" src="https://github.com/user-attachments/assets/81d39ae0-9d69-4409-8704-91e96bd80cd2" />

* Add command-aware result history entries as: > COMMAND \n RESULT
* Add unit tests for result history formatting
* Guard person selection callback against null values during list refresh (#117 found and fixed)