### PR TITLE
Refine duplicate handling for locked and unlocked modes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -30,7 +30,6 @@ import seedu.address.model.tag.Tag;
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "
@@ -85,15 +84,7 @@ public class AddCommand extends Command {
         AppMode appMode = context.getAppMode();
 
         Person personToAdd = createPersonForMode(appMode);
-        Person personToOverride = findSamePerson(model, personToAdd);
-
-        if (personToOverride != null && !shouldOverrideDuplicate(appMode, personToOverride)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-        }
-
-        if (personToOverride != null) {
-            model.deletePerson(personToOverride, appMode);
-        }
+        CommandUtil.resolveDuplicateConflict(model, personToAdd, appMode, null);
 
         model.addPerson(personToAdd, appMode);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personToAdd)));
@@ -105,17 +96,6 @@ public class AddCommand extends Command {
 
     private static PersonStatus getStatusForMode(AppMode appMode) {
         return appMode == AppMode.LOCKED ? PersonStatus.LOCKED : PersonStatus.UNLOCKED;
-    }
-
-    private static Person findSamePerson(Model model, Person target) {
-        return model.getPersonList().stream()
-                .filter(target::isSamePerson)
-                .findFirst()
-                .orElse(null);
-    }
-
-    private static boolean shouldOverrideDuplicate(AppMode appMode, Person personToOverride) {
-        return appMode == AppMode.LOCKED && personToOverride.getStatus() == PersonStatus.UNLOCKED;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/CommandUtil.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.address.logic.AppMode;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonStatus;
+
+/**
+ * Shared helper methods for command duplicate-handling logic.
+ */
+public final class CommandUtil {
+
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+
+    private CommandUtil() {
+
+    }
+
+    /**
+     * Resolves duplicate handling for add/edit flows.
+     * If a conflicting person exists, either delete it when override is allowed
+     * or throw a {@code CommandException} otherwise.
+     *
+     * @param personToIgnore the person to exclude from duplicate checks, used by edit flows
+     */
+    public static void resolveDuplicateConflict(Model model, Person personToProcess,
+            AppMode appMode, Person personToIgnore) throws CommandException {
+        requireAllNonNull(model, personToProcess, appMode);
+
+        Person personToOverride = findDuplicatePerson(model, personToProcess, personToIgnore);
+
+        if (personToOverride == null) {
+            return;
+        }
+
+        if (!canOverrideExisting(appMode, personToOverride)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.deletePerson(personToOverride, appMode);
+    }
+
+    private static Person findDuplicatePerson(Model model, Person personToProcess, Person personToIgnore) {
+        return model.getPersonList().stream()
+                .filter(person -> !person.equals(personToIgnore) && person.isSamePerson(personToProcess))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Returns whether the conflicting existing person can be overridden in the current app mode.
+     */
+    public static boolean canOverrideExisting(AppMode appMode, Person personToOverride) {
+        requireAllNonNull(appMode, personToOverride);
+        return appMode == AppMode.LOCKED && personToOverride.getStatus() == PersonStatus.UNLOCKED;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -26,7 +26,6 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.PersonStatus;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
@@ -52,7 +51,6 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -82,15 +80,8 @@ public class EditCommand extends Command {
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
-        Person personToOverride = findPersonToOverride(model, personToEdit, editedPerson);
 
-        if (personToOverride != null && !shouldOverrideDuplicate(appMode, personToOverride)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-        }
-
-        if (personToOverride != null) {
-            model.deletePerson(personToOverride, appMode);
-        }
+        CommandUtil.resolveDuplicateConflict(model, editedPerson, appMode, personToEdit);
 
         model.setPerson(personToEdit, editedPerson, appMode);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS, appMode);
@@ -112,17 +103,6 @@ public class EditCommand extends Command {
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
                 personToEdit.getStatus());
-    }
-
-    private static Person findPersonToOverride(Model model, Person personToEdit, Person editedPerson) {
-        return model.getPersonList().stream()
-                .filter(person -> !person.equals(personToEdit) && person.isSamePerson(editedPerson))
-                .findFirst()
-                .orElse(null);
-    }
-
-    private static boolean shouldOverrideDuplicate(AppMode appMode, Person personToOverride) {
-        return appMode == AppMode.LOCKED && personToOverride.getStatus() == PersonStatus.UNLOCKED;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -47,7 +47,7 @@ public class AddCommandIntegrationTest {
         Person personToAdd = new PersonBuilder(existingPerson).build();
 
         assertCommandFailure(new AddCommand(personToAdd), model, AppMode.UNLOCKED,
-                AddCommand.MESSAGE_DUPLICATE_PERSON);
+                CommandUtil.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -56,7 +56,7 @@ public class AddCommandTest {
 
         CommandContext context = new CommandContext(modelStub, AppMode.UNLOCKED);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () ->
+        assertThrows(CommandException.class, CommandUtil.MESSAGE_DUPLICATE_PERSON, () ->
             new AddCommand(existingPerson).execute(context));
         assertEquals(Arrays.asList(existingPerson), modelStub.persons);
         assertTrue(modelStub.getDeletedPerson() == null);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -114,7 +114,7 @@ public class EditCommandTest {
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, TEST_MODE, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, TEST_MODE, CommandUtil.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Refined duplicate handling for `add` and `edit` so override is no longer unconditional across modes.

## What changed
- Restored duplicate failure as the default behavior for `add` and `edit`
- Allowed a special-case override only when:
  - the app is in locked mode
  - the existing duplicate has `UNLOCKED` status
- Kept locked mode able to replace an unlocked duplicate
- Prevented duplicate overrides in unlocked mode
- Prevented locked-mode overrides against already locked duplicates
- Updated command tests and integration tests to cover the new selective override behavior

## Testing
- `./gradlew check`
- Manual app verification for:
  - locked add overriding an unlocked duplicate
  - locked add rejecting a locked duplicate
  - unlocked add rejecting duplicates
  - locked edit overriding an unlocked duplicate
  - locked/unlocked edit rejecting normal duplicate collisions