### PR TITLE
Refactor CommandUtil with tests, refactor PersonStatus enum names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -17,6 +17,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.AppMode;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.util.CommandUtil;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -106,7 +107,7 @@ public class AddCommand extends Command {
     }
 
     private static PersonStatus getStatusForMode(AppMode appMode) {
-        return appMode == AppMode.LOCKED ? PersonStatus.LOCKED : PersonStatus.UNLOCKED;
+        return appMode == AppMode.LOCKED ? PersonStatus.PUBLIC : PersonStatus.SENSITIVE;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -21,6 +21,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.AppMode;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.util.CommandUtil;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;

--- a/src/main/java/seedu/address/logic/commands/ToggleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ToggleCommand.java
@@ -55,9 +55,9 @@ public class ToggleCommand extends Command {
     }
 
     private static Person createToggledPerson(Person person) {
-        PersonStatus toggledStatus = person.getStatus() == PersonStatus.LOCKED
-                ? PersonStatus.UNLOCKED
-                : PersonStatus.LOCKED;
+        PersonStatus toggledStatus = person.getStatus() == PersonStatus.PUBLIC
+                ? PersonStatus.SENSITIVE
+                : PersonStatus.PUBLIC;
 
         return new Person(person.getName(), person.getPhone(), person.getEmail(),
                 person.getAddress(), person.getTags(), toggledStatus);

--- a/src/main/java/seedu/address/logic/commands/util/CommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandUtil.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.util;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
@@ -55,6 +55,6 @@ public final class CommandUtil {
      */
     public static boolean canOverrideExisting(AppMode appMode, Person personToOverride) {
         requireAllNonNull(appMode, personToOverride);
-        return appMode == AppMode.LOCKED && personToOverride.getStatus() == PersonStatus.UNLOCKED;
+        return appMode == AppMode.LOCKED && personToOverride.getStatus() == PersonStatus.SENSITIVE;
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -37,7 +37,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         this.filteredLockedPersons = new FilteredList<>(this.addressBook.getPersonList(),
-                person -> person.getStatus() == PersonStatus.LOCKED);
+                person -> person.getStatus() == PersonStatus.PUBLIC);
         this.filteredUnlockedPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
@@ -114,7 +114,7 @@ public class ModelManager implements Model {
         requireNonNull(appMode);
 
         if (isLockedMode(appMode)) {
-            addressBook.clearPersonsWithStatus(PersonStatus.LOCKED);
+            addressBook.clearPersonsWithStatus(PersonStatus.PUBLIC);
         } else {
             addressBook.clearPersons();
         }
@@ -162,7 +162,7 @@ public class ModelManager implements Model {
 
         if (isLockedMode(appMode)) {
             filteredLockedPersons.setPredicate(person ->
-                    person.getStatus() == PersonStatus.LOCKED && predicate.test(person));
+                    person.getStatus() == PersonStatus.PUBLIC && predicate.test(person));
         } else {
             filteredUnlockedPersons.setPredicate(predicate);
         }

--- a/src/main/java/seedu/address/model/person/PersonStatus.java
+++ b/src/main/java/seedu/address/model/person/PersonStatus.java
@@ -4,10 +4,10 @@ package seedu.address.model.person;
  * Represents the visibility status of a person entry.
  */
 public enum PersonStatus {
-    LOCKED(0),
-    UNLOCKED(1);
+    PUBLIC(0),
+    SENSITIVE(1);
 
-    public static final String MESSAGE_CONSTRAINTS = "Person status must be 0 (locked) or 1 (unlocked).";
+    public static final String MESSAGE_CONSTRAINTS = "Person status must be 0 (public) or 1 (sensitive).";
 
     private final int code;
 
@@ -21,7 +21,7 @@ public enum PersonStatus {
 
     @Override
     public String toString() {
-        return this == LOCKED ? "Public" : "Sensitive";
+        return this == PUBLIC ? "Public" : "Sensitive";
     }
 
     /**
@@ -32,9 +32,9 @@ public enum PersonStatus {
     public static PersonStatus fromCode(int code) {
         switch (code) {
         case 0:
-            return LOCKED;
+            return PUBLIC;
         case 1:
-            return UNLOCKED;
+            return SENSITIVE;
         default:
             throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -22,22 +22,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), PersonStatus.LOCKED),
+                getTagSet("friends"), PersonStatus.PUBLIC),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), PersonStatus.LOCKED),
+                getTagSet("colleagues", "friends"), PersonStatus.PUBLIC),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), PersonStatus.LOCKED),
+                getTagSet("neighbours"), PersonStatus.PUBLIC),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), PersonStatus.LOCKED),
+                getTagSet("family"), PersonStatus.PUBLIC),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), PersonStatus.LOCKED),
+                getTagSet("classmates"), PersonStatus.PUBLIC),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), PersonStatus.LOCKED)
+                getTagSet("colleagues"), PersonStatus.PUBLIC)
         };
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -223,7 +223,7 @@ public class LogicManagerTest {
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY)
                 .withTags()
-                .withStatus(PersonStatus.UNLOCKED)
+                .withStatus(PersonStatus.SENSITIVE)
                 .build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson, AppMode.UNLOCKED);

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.AppMode;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.util.CommandUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -55,9 +56,9 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_unlockedDuplicateInLockedMode_replacesExistingPerson() {
-        Person existingUnlockedPerson = new PersonBuilder().withStatus(PersonStatus.UNLOCKED).build();
+        Person existingUnlockedPerson = new PersonBuilder().withStatus(PersonStatus.SENSITIVE).build();
         Person personToAdd = new PersonBuilder(existingUnlockedPerson).build();
-        Person expectedPerson = new PersonBuilder(existingUnlockedPerson).withStatus(PersonStatus.LOCKED).build();
+        Person expectedPerson = new PersonBuilder(existingUnlockedPerson).withStatus(PersonStatus.PUBLIC).build();
 
         AddressBook addressBook = new AddressBook();
         addressBook.addPerson(existingUnlockedPerson);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.AppMode;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.util.CommandUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -40,7 +41,7 @@ public class AddCommandTest {
     public void execute_personAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         Person validPerson = new PersonBuilder().build();
-        Person expectedPerson = new PersonBuilder(validPerson).withStatus(PersonStatus.UNLOCKED).build();
+        Person expectedPerson = new PersonBuilder(validPerson).withStatus(PersonStatus.SENSITIVE).build();
 
         CommandContext context = new CommandContext(modelStub, AppMode.UNLOCKED);
         CommandResult commandResult = new AddCommand(validPerson).execute(context);
@@ -67,8 +68,8 @@ public class AddCommandTest {
 
     @Test
     public void execute_unlockedDuplicateInLockedMode_replacesExistingPerson() throws Exception {
-        Person existingUnlockedPerson = new PersonBuilder().withStatus(PersonStatus.UNLOCKED).build();
-        Person expectedPerson = new PersonBuilder(existingUnlockedPerson).withStatus(PersonStatus.LOCKED).build();
+        Person existingUnlockedPerson = new PersonBuilder().withStatus(PersonStatus.SENSITIVE).build();
+        Person expectedPerson = new PersonBuilder(existingUnlockedPerson).withStatus(PersonStatus.PUBLIC).build();
         ModelStubWithExistingPerson modelStub = new ModelStubWithExistingPerson(existingUnlockedPerson);
 
         CommandContext context = new CommandContext(modelStub, AppMode.LOCKED);

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -28,7 +28,7 @@ public class ClearCommandTest {
 
     @Test
     public void execute_mixedAddressBookLockedMode_clearsOnlyLockedPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder()
                 .withPerson(ALICE)
                 .withPerson(unlockedBenson)
@@ -43,7 +43,7 @@ public class ClearCommandTest {
 
     @Test
     public void execute_mixedAddressBookUnlockedMode_clearsAllPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder()
                 .withPerson(ALICE)
                 .withPerson(unlockedBenson)

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.AppMode;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.util.CommandUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -137,9 +138,9 @@ public class EditCommandTest {
                 .withPhone("81234567")
                 .withEmail("duplicate@example.com")
                 .withAddress("123 Duplicate Street")
-                .withStatus(PersonStatus.UNLOCKED)
+                .withStatus(PersonStatus.SENSITIVE)
                 .build();
-        Person editedPerson = new PersonBuilder(hiddenUnlockedDuplicate).withStatus(PersonStatus.LOCKED).build();
+        Person editedPerson = new PersonBuilder(hiddenUnlockedDuplicate).withStatus(PersonStatus.PUBLIC).build();
 
         AddressBook addressBook = new AddressBook();
         addressBook.addPerson(personToEdit);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -77,7 +77,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_unlockedPersonInLockedMode_noPersonFound() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder()
                 .withPerson(ALICE)
                 .withPerson(unlockedBenson)
@@ -98,7 +98,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_unlockedPersonInUnlockedMode_personFound() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder()
                 .withPerson(ALICE)
                 .withPerson(unlockedBenson)

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -39,7 +39,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFilteredInLockedMode_showsOnlyLockedPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder()
                 .withPerson(ALICE)
                 .withPerson(unlockedBenson)
@@ -55,7 +55,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFilteredInUnlockedMode_showsEverything() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder()
                 .withPerson(ALICE)
                 .withPerson(unlockedBenson)

--- a/src/test/java/seedu/address/logic/commands/ToggleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ToggleCommandTest.java
@@ -39,7 +39,7 @@ public class ToggleCommandTest {
     @Test
     public void execute_toggleLockedPersonUnfilteredList_success() {
         Person personToToggle = model.getFilteredPersonList(TEST_MODE).get(INDEX_FIRST_PERSON.getZeroBased());
-        Person toggledPerson = new PersonBuilder(personToToggle).withStatus(PersonStatus.UNLOCKED).build();
+        Person toggledPerson = new PersonBuilder(personToToggle).withStatus(PersonStatus.SENSITIVE).build();
         ToggleCommand toggleCommand = new ToggleCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(ToggleCommand.MESSAGE_TOGGLE_PERSON_SUCCESS,
@@ -54,12 +54,12 @@ public class ToggleCommandTest {
 
     @Test
     public void execute_toggleUnlockedPersonUnfilteredList_success() {
-        Person unlockedPerson = new PersonBuilder().withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedPerson = new PersonBuilder().withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBook();
         addressBook.addPerson(unlockedPerson);
         Model customModel = new ModelManager(addressBook, new UserPrefs());
 
-        Person toggledPerson = new PersonBuilder(unlockedPerson).withStatus(PersonStatus.LOCKED).build();
+        Person toggledPerson = new PersonBuilder(unlockedPerson).withStatus(PersonStatus.PUBLIC).build();
         ToggleCommand toggleCommand = new ToggleCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(ToggleCommand.MESSAGE_TOGGLE_PERSON_SUCCESS,
@@ -86,7 +86,7 @@ public class ToggleCommandTest {
         showUnlockedPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToToggle = model.getFilteredPersonList(TEST_MODE).get(INDEX_FIRST_PERSON.getZeroBased());
-        Person toggledPerson = new PersonBuilder(personToToggle).withStatus(PersonStatus.UNLOCKED).build();
+        Person toggledPerson = new PersonBuilder(personToToggle).withStatus(PersonStatus.SENSITIVE).build();
         ToggleCommand toggleCommand = new ToggleCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(ToggleCommand.MESSAGE_TOGGLE_PERSON_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/util/CommandUtilTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/CommandUtilTest.java
@@ -1,0 +1,239 @@
+package seedu.address.logic.commands.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.util.CommandUtil.MESSAGE_DUPLICATE_PERSON;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.AppMode;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonStatus;
+import seedu.address.testutil.PersonBuilder;
+
+public class CommandUtilTest {
+
+    @Test
+    public void resolveDuplicateConflict_nullArguments_throwsNullPointerException() {
+        Model modelStub = new ModelStubAcceptingDuplicate(null);
+        Person personToProcess = new PersonBuilder().build();
+
+        assertThrows(NullPointerException.class, () ->
+                CommandUtil.resolveDuplicateConflict(null, personToProcess, AppMode.LOCKED, null));
+        assertThrows(NullPointerException.class, () ->
+                CommandUtil.resolveDuplicateConflict(modelStub, null, AppMode.LOCKED, null));
+        assertThrows(NullPointerException.class, () ->
+                CommandUtil.resolveDuplicateConflict(modelStub, personToProcess, null, null));
+    }
+
+    @Test
+    public void resolveDuplicateConflict_noDuplicateExists_success() {
+        ModelStubAcceptingDuplicate modelStub = new ModelStubAcceptingDuplicate(null);
+        Person personToProcess = new PersonBuilder().withName("Alice").build();
+        Person personToIgnore = new PersonBuilder().withName("Bob").build();
+
+        assertDoesNotThrow(() ->
+                CommandUtil.resolveDuplicateConflict(modelStub, personToProcess, AppMode.LOCKED, personToIgnore));
+    }
+
+    @Test
+    public void resolveDuplicateConflict_duplicateExistsButIsIgnored_success() {
+        Person existingPerson = new PersonBuilder().withName("Alice").build();
+        ModelStubAcceptingDuplicate modelStub = new ModelStubAcceptingDuplicate(existingPerson);
+
+        // We tell it to process Alice, but also to ignore Alice. It should succeed without doing anything.
+        assertDoesNotThrow(() ->
+                CommandUtil.resolveDuplicateConflict(modelStub, existingPerson, AppMode.LOCKED, existingPerson));
+    }
+
+    @Test
+    public void resolveDuplicateConflict_duplicateExistsCannotOverride_throwsCommandException() {
+        Person personToProcess = new PersonBuilder().withName("Alice").build();
+        // The existing duplicate is Public, meaning it cannot be overridden
+        Person existingDuplicate = new PersonBuilder().withName("Alice").withStatus(PersonStatus.PUBLIC).build();
+        ModelStubAcceptingDuplicate modelStub = new ModelStubAcceptingDuplicate(existingDuplicate);
+
+        CommandException thrown = assertThrows(CommandException.class, () ->
+                CommandUtil.resolveDuplicateConflict(modelStub, personToProcess, AppMode.LOCKED, null));
+
+        assertEquals(MESSAGE_DUPLICATE_PERSON, thrown.getMessage());
+    }
+
+    @Test
+    public void resolveDuplicateConflict_duplicateExistsCanOverride_deletesExisting() throws Exception {
+        Person personToProcess = new PersonBuilder().withName("Alice").build();
+        // The existing duplicate is Sensitive, meaning it CAN be overridden in LOCKED mode
+        Person existingDuplicate = new PersonBuilder().withName("Alice").withStatus(PersonStatus.SENSITIVE).build();
+        ModelStubAcceptingDuplicate modelStub = new ModelStubAcceptingDuplicate(existingDuplicate);
+
+        CommandUtil.resolveDuplicateConflict(modelStub, personToProcess, AppMode.LOCKED, null);
+
+        // Verify that the duplicate was deleted from the model
+        assertEquals(existingDuplicate, modelStub.getDeletedPerson());
+    }
+
+    @Test
+    public void canOverrideExisting_nullArguments_throwsNullPointerException() {
+        Person person = new PersonBuilder().withStatus(PersonStatus.SENSITIVE).build();
+        assertThrows(NullPointerException.class, () -> CommandUtil.canOverrideExisting(null, person));
+        assertThrows(NullPointerException.class, () -> CommandUtil.canOverrideExisting(AppMode.LOCKED, null));
+    }
+
+    @Test
+    public void canOverrideExisting_appModeLockedAndPersonUnlocked_returnsTrue() {
+        Person personToOverride = new PersonBuilder().withStatus(PersonStatus.SENSITIVE).build();
+        assertTrue(CommandUtil.canOverrideExisting(AppMode.LOCKED, personToOverride));
+    }
+
+    @Test
+    public void canOverrideExisting_appModeLockedAndPersonLocked_returnsFalse() {
+        Person personToOverride = new PersonBuilder().withStatus(PersonStatus.PUBLIC).build();
+        assertFalse(CommandUtil.canOverrideExisting(AppMode.LOCKED, personToOverride));
+    }
+
+    @Test
+    public void canOverrideExisting_appModeUnlocked_returnsFalse() {
+        Person unlockedPerson = new PersonBuilder().withStatus(PersonStatus.SENSITIVE).build();
+        assertFalse(CommandUtil.canOverrideExisting(AppMode.UNLOCKED, unlockedPerson));
+
+        Person lockedPerson = new PersonBuilder().withStatus(PersonStatus.PUBLIC).build();
+        assertFalse(CommandUtil.canOverrideExisting(AppMode.UNLOCKED, lockedPerson));
+    }
+
+    /**
+     * A default model stub that has all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person, AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target, AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void clearPersons(AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person, AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson, AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList(AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String getAddressBookPassword() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookPassword(String password) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate, AppMode appMode) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that starts with one existing person and tracks deletions
+     * specifically for testing CommandUtil.
+     */
+    private class ModelStubAcceptingDuplicate extends ModelStub {
+        private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private Person deletedPerson = null;
+
+        ModelStubAcceptingDuplicate(Person existingPerson) {
+            if (existingPerson != null) {
+                persons.add(existingPerson);
+            }
+        }
+
+        @Override
+        public ObservableList<Person> getPersonList() {
+            return persons;
+        }
+
+        @Override
+        public void deletePerson(Person target, AppMode appMode) {
+            this.deletedPerson = target;
+        }
+
+        public Person getDeletedPerson() {
+            return deletedPerson;
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -95,7 +95,7 @@ public class ModelManagerTest {
 
     @Test
     public void hasPerson_sameIdentityDifferentStatus_returnsTrue() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder().withPerson(unlockedBenson).build();
         modelManager = new ModelManager(addressBook, new UserPrefs());
 
@@ -110,7 +110,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_lockedMode_showsOnlyLockedPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(unlockedBenson).build();
         modelManager = new ModelManager(addressBook, new UserPrefs());
 
@@ -120,7 +120,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_unlockedMode_showsAllPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(unlockedBenson).build();
         modelManager = new ModelManager(addressBook, new UserPrefs());
 
@@ -131,7 +131,7 @@ public class ModelManagerTest {
 
     @Test
     public void clearPersons_lockedMode_removesOnlyLockedPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(unlockedBenson).build();
         modelManager = new ModelManager(addressBook, new UserPrefs());
 
@@ -146,7 +146,7 @@ public class ModelManagerTest {
 
     @Test
     public void clearPersons_unlockedMode_removesAllPersons() {
-        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.UNLOCKED).build();
+        Person unlockedBenson = new PersonBuilder(BENSON).withStatus(PersonStatus.SENSITIVE).build();
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(unlockedBenson).build();
         modelManager = new ModelManager(addressBook, new UserPrefs());
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -38,7 +38,7 @@ public class PersonTest {
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // same name, different status -> returns true
-        editedAlice = new PersonBuilder(ALICE).withStatus(PersonStatus.UNLOCKED).build();
+        editedAlice = new PersonBuilder(ALICE).withStatus(PersonStatus.SENSITIVE).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -94,7 +94,7 @@ public class PersonTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different status -> returns false
-        editedAlice = new PersonBuilder(ALICE).withStatus(PersonStatus.UNLOCKED).build();
+        editedAlice = new PersonBuilder(ALICE).withStatus(PersonStatus.SENSITIVE).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -38,7 +38,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
-        status = PersonStatus.LOCKED;
+        status = PersonStatus.PUBLIC;
     }
 
     /**


### PR DESCRIPTION
## Description
This PR performs a semantic refactor of the contact status and application mode enums to align with the new visibility architecture. It also introduces a robust test suite for `CommandUtil` using internal `Model` stubs.

### Key Changes
1.  **Enum Renaming**:
    * `PersonStatus.UNLOCKED` → `PersonStatus.SENSITIVE`
    * `PersonStatus.LOCKED` → `PersonStatus.PUBLIC`
2.  **Testing**:
    * Added `CommandUtilTest.java` with a comprehensive `ModelStub` to verify duplicate resolution.