### PR TITLE
Refactor Javadocs of SetupCommand and isAnySelected (renamed to isSelectionEmpty)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SetupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetupCommand.java
@@ -6,7 +6,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 
 /**
  * Transitions the application to the Setup state.
- * This command is only accessible when the application is currently locked.
+ * This command is only accessible when the application is currently unlocked.
  */
 public class SetupCommand extends Command {
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -157,13 +157,13 @@ public class MainWindow extends UiPart<Stage> {
         commandBox.requestFocus();
 
         if (isShiftDown) {
-            if (personListPanel.isAnySelected()) {
+            if (personListPanel.isSelectionEmpty()) {
                 personListPanel.selectLast();
             } else {
                 personListPanel.selectPrevious();
             }
         } else {
-            if (personListPanel.isAnySelected()) {
+            if (personListPanel.isSelectionEmpty()) {
                 personListPanel.selectFirst();
             } else {
                 personListPanel.selectNext();

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -130,16 +130,16 @@ public class PersonListPanel extends UiPart<Region> {
             return;
         }
         personListView.getSelectionModel().selectLast();
-        // Bottom align for  last item
+        // Bottom align for last item
         scrollToVisible(size - 1, true);
     }
 
     /**
-     * Returns true if a person is currently selected.
+     * Returns true if no person is currently selected.
      *
-     * @return True if selection exists.
+     * @return True if selection does not exist.
      */
-    public boolean isAnySelected() {
+    public boolean isSelectionEmpty() {
         return personListView.getSelectionModel().getSelectedIndex() < 0;
     }
 


### PR DESCRIPTION

## Description
Renamed `isAnySelected` to `isSelectionEmpty` to fix the logic-Javadoc contradiction. Also updated `SetupCommand` Javadocs for better clarity on its role in the initialization flow.

### Changes

**PersonListPanel.java**
- Renamed `isAnySelected()` -> `isSelectionEmpty()`
- Updated Javadoc to reflect that `true` indicates no selection exists.

**SetupCommand.java**
- Change from only in locked mode to only in unlocked mode