### PR TITLE
Update duplicate detection to use name and phone

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -38,6 +38,13 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if both names are the same, ignoring letter case.
+     */
+    public boolean isSameName(Name otherName) {
+        return otherName != null
+                && fullName.equalsIgnoreCase(otherName.fullName);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -68,7 +68,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same name ignoring case, and the same phone number.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -77,7 +77,8 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getPhone().equals(getPhone())
+                && otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -78,7 +78,7 @@ public class Person {
 
         return otherPerson != null
                 && otherPerson.getPhone().equals(getPhone())
-                && otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName);
+                && otherPerson.getName().isSameName(getName());
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -32,24 +32,28 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
-        Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+        // same name and phone, all other attributes different -> returns true
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // same name, different status -> returns true
+        // same name and phone, different status -> returns true
         editedAlice = new PersonBuilder(ALICE).withStatus(PersonStatus.SENSITIVE).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // same name but different phone -> returns false
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, same phone -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, same phone -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSamePerson(editedBob));


### PR DESCRIPTION
Summary:
- updated duplicate detection to use both name and phone number instead of name alone
- made name comparison case-insensitive for duplicate checks
- updated the `Person` identity tests to match the new behavior

Behavior:
- contacts are now treated as duplicates only when their names match ignoring case and their phone numbers are the same
- same name with different phone numbers is allowed
- same phone number with different names is allowed
