### PR TITLE
Cap command/result history

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -804,6 +804,8 @@ The sequence diagram below shows the successful unlock path and the incorrect-pa
 
 1. The application should **preserve data** across restarts and **recover cleanly** from invalid or corrupted stored data.
 2. Saved data should remain **human-readable** and be **validated** before it is loaded.
+3. In-memory command and result histories should be bounded to prevent unbounded memory growth
+  (retain only the most recent **100 commands** and **200 result entries**).
 
 #### Accessibility
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,12 +108,14 @@ This is the main interface of SpyGlass. It consists of:
 * **Contact Details** — Displays contact information in full detail (with email, address etc.) of the currently selected contact.
 * **Command Box** — This is where you enter commands to interact with SpyGlass. Type your command here and press **Enter** to execute it.
 * **Result History** - Displays the list of feedback messages of the commands you entered in the command box.
+  It stores up to the **most recent 200 entries**.
 
 <box type="tip" seamless>
 
 **Tip — Keyboard Navigation:**
 
 * Use <kbd>Up</kbd> and <kbd>Down</kbd> in the Command Box to cycle through your past commands in the current mode, so you can quickly reuse and modify them.
+  Command history stores up to the **most recent 100 commands**.
 * Use <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> to cycle through the displayed contact list. The selected contact will be highlighted and its full details will appear in the Contact Details panel.
 
 </box>

--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -7,6 +7,8 @@ import java.util.List;
  * Stores the history of commands executed.
  */
 public class CommandHistory {
+    private static final int MAX_ENTRIES = 100;
+
     private final List<String> history = new ArrayList<>();
     private int currentIndex = 0;
 
@@ -17,6 +19,11 @@ public class CommandHistory {
         if (command == null || command.trim().isEmpty()) {
             return;
         }
+
+        if (history.size() == MAX_ENTRIES) {
+            history.remove(0);
+        }
+
         history.add(command);
         currentIndex = history.size();
     }

--- a/src/main/java/seedu/address/ui/ResultHistory.java
+++ b/src/main/java/seedu/address/ui/ResultHistory.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
@@ -13,7 +14,9 @@ import javafx.scene.layout.Region;
  */
 public class ResultHistory extends UiPart<Region> {
 
+    private static final int MAX_ENTRIES = 200;
     private static final String FXML = "ResultHistory.fxml";
+
     // Non-persistent memory for the result history
     private static ArrayList<String> log = new ArrayList<>();
 
@@ -49,12 +52,16 @@ public class ResultHistory extends UiPart<Region> {
 
     private void appendEntry(String entry) {
         log.add(entry);
+        log = new ArrayList<>(capEntries(log, MAX_ENTRIES));
+        resultHistory.setText(String.join("\n\n", log));
+    }
 
-        if (resultHistory.getText().isEmpty()) {
-            resultHistory.setText(entry);
-        } else {
-            resultHistory.appendText("\n\n" + entry);
+    static List<String> capEntries(List<String> entries, int maxEntries) {
+        if (entries.size() <= maxEntries) {
+            return new ArrayList<>(entries);
         }
+
+        return new ArrayList<>(entries.subList(entries.size() - maxEntries, entries.size()));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/logic/CommandHistoryTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Test;
 
 public class CommandHistoryTest {
 
+    private static final int HISTORY_CAP = 100;
+    private static final int COMMANDS_ADDED = HISTORY_CAP + 1;
+
     private CommandHistory history;
 
     @BeforeEach
@@ -74,5 +77,23 @@ public class CommandHistoryTest {
 
         assertEquals("", history.getPrevious());
         assertEquals("", history.getNext());
+    }
+
+    @Test
+    public void add_exceedsMaxEntries_dropsOldestCommand() {
+        for (int i = 1; i <= COMMANDS_ADDED; i++) {
+            history.add("cmd" + i);
+        }
+
+        // Newest command should still be available first.
+        assertEquals("cmd" + COMMANDS_ADDED, history.getPrevious());
+
+        // Traversing to the oldest retained command should skip the dropped one (cmd1).
+        String oldestRetained = "";
+        for (int i = 0; i < HISTORY_CAP - 1; i++) {
+            oldestRetained = history.getPrevious();
+        }
+        assertEquals("cmd2", oldestRetained);
+        assertEquals("cmd2", history.getPrevious());
     }
 }

--- a/src/test/java/seedu/address/ui/ResultHistoryTest.java
+++ b/src/test/java/seedu/address/ui/ResultHistoryTest.java
@@ -2,6 +2,8 @@ package seedu.address.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 public class ResultHistoryTest {
@@ -15,5 +17,17 @@ public class ResultHistoryTest {
     public void formatCommandResultEntry_formatsAsTwoLines() {
         assertEquals("> CMD entered\nResult OUTPUT",
                 ResultHistory.formatCommandResultEntry("CMD entered", "Result OUTPUT"));
+    }
+
+    @Test
+    public void capEntries_withinLimit_keepsAllEntries() {
+        List<String> entries = List.of("a", "b", "c");
+        assertEquals(entries, ResultHistory.capEntries(entries, 3));
+    }
+
+    @Test
+    public void capEntries_exceedsLimit_keepsMostRecentEntries() {
+        List<String> entries = List.of("a", "b", "c", "d");
+        assertEquals(List.of("c", "d"), ResultHistory.capEntries(entries, 2));
     }
 }


### PR DESCRIPTION
- bound CommandHistory to the most recent 100 commands
- bound ResultHistory to the most recent 200 feedback entries
- update history tests to verify eviction/retention behavior
- document command/result history retention limits in UG and DG